### PR TITLE
Turn on hashing to allow deep links

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -56,6 +56,7 @@ var client = new MapboxClient(mapboxgl.accessToken);
 
 var geocoder = new MapboxGeocoder({
   placeholder: 'Search a location',
+  hash: true,
   flyTo: false,
   accessToken: mapboxgl.accessToken
 });

--- a/js/site.js
+++ b/js/site.js
@@ -48,7 +48,7 @@ var map = new mapboxgl.Map({
   container: 'map',
   style: 'mapbox://styles/mapbox/dark-v9',
   center: ClimateChangeProjections.map.center,
-  zoom: ClimateChangeProjections.map.zoom
+  zoom: ClimateChangeProjections.map.zoom,
 });
 
 // Disable scroll zooming in iframe
@@ -60,8 +60,7 @@ var client = new MapboxClient(mapboxgl.accessToken);
 
 var geocoder = new MapboxGeocoder({
   placeholder: 'Search a location',
-  hash: true,
-  flyTo: false,
+  flyTo: true,
   accessToken: mapboxgl.accessToken
 });
 


### PR DESCRIPTION
Fixes #2.

Based on https://docs.mapbox.com/mapbox-gl-js/api/#map.

![image](https://user-images.githubusercontent.com/1791439/66033818-61f0f500-e54b-11e9-8509-8a2d32e5741c.png)
